### PR TITLE
Manifest now exists, and has rules!

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ Which means most interactive fiction games with save states will work.
 Note: if you use termux + curl to download files, you will have to set the
 `allow-external-apps` property must be set to `true` in `~/.termux/termux.properties` in termux.
 
+## Manifests
+
+Create a `ozb_manifest.json` file in your zipped html app next to your index.html with a variety of useful settings that will control how the app is loaded. Generally these properties will help misbehaving applications work better.
+
+Theoretically I'd like to be able to clear cache for a site on startup, but it's not built into web views by default that I can tell.
+
+### `dateToSpoof`
+
+Offset based timestamp, loaded with OffsetDateTime.parse.
+Values like "2025-01-30T19:00:00-05:00" will work.
+
+### `useUnsafeURL`
+
+Set the base url of the app to a "real" url. The app will still try to prevent access to the wider web.
+
 ## Deep Links
 
 Deep links to link into the app. Because the app is intentionally not communicating with servers or other apps, deep links do not work inside the app, so you can only link in from another app.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "foss.zip.offline.browser.offlinezipbrowser"
         minSdk 26
         targetSdk 33
-        versionCode 12
-        versionName "0.12.0"
+        versionCode 13
+        versionName "0.12.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "foss.zip.offline.browser.offlinezipbrowser"
         minSdk 26
         targetSdk 33
-        versionCode 11
-        versionName "0.11.0"
+        versionCode 12
+        versionName "0.12.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId "foss.zip.offline.browser.offlinezipbrowser"
-        minSdk 21
+        minSdk 26
         targetSdk 33
         versionCode 11
         versionName "0.11.0"

--- a/app/src/main/assets/dateReplacer.js
+++ b/app/src/main/assets/dateReplacer.js
@@ -1,0 +1,20 @@
+Date = (function (_date) {
+    const _now = Date.now;
+      const baseDate = (new Date("%%DATE_GOES_HERE%%")).getTime();
+      const loadTime = (new Date()).getTime();
+      const offset = loadTime - baseDate;
+	  const newDate = function(x) {
+	    if(x == null) {
+	        const pure = new _date();
+	      	pure.setTime(pure.getTime()-offset);
+	      	return pure;
+	    }
+	    return new _date(x);
+	  };
+
+	  newDate.prototype = _date.prototype;
+	  newDate.now = function(){
+	    return _date.now() - offset;
+	  }
+	  return newDate;
+})(Date);

--- a/app/src/main/java/foss/zip/offline/browser/offlinezipbrowser/ZipAssetLoader.kt
+++ b/app/src/main/java/foss/zip/offline/browser/offlinezipbrowser/ZipAssetLoader.kt
@@ -16,8 +16,6 @@ import java.util.zip.ZipFile
 
 const val KEY_DATE_TO_SPOOF = "dateToSpoof"
 const val KEY_USE_UNSAFE_URL = "useUnsafeURL"
-const val KEY_WIPE_CACHE = "wipeCacheOnStart"
-const val KEY_WIPE_CACHE_NO_DISK = "wipeCachePreserveDisk"
 
 class ZipAssetLoader(private val zipFile: ZipFile, private val loadedFileName: String, private val downloadHelperScript: String, private val dateReplacementScript: String) : WebViewClientCompat() {
     private val utf8: String = Charsets.UTF_8.displayName()
@@ -26,19 +24,18 @@ class ZipAssetLoader(private val zipFile: ZipFile, private val loadedFileName: S
     // manifest config block
     private val manifest = getManifest(basePath)
     val baseURL = findBaseURL(manifest)
-    private val shouldClearCache = checkShouldClearCache(manifest)
-    private val shouldClearCacheKeepDisk = checkShouldClearCacheAndPreserveDisk(manifest)
     private val dateToSpoof = manifestDateToSpoof(manifest)
 
     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
         super.onPageStarted(view, url, favicon)
         view?.evaluateJavascript(downloadHelperScript, null)
 
-        if (shouldClearCache) {
+        // TODO clear cache for sites better
+        /*if (shouldClearCache) {
             view?.clearCache(true)
         } else if (shouldClearCacheKeepDisk) {
             view?.clearCache(false)
-        }
+        }*/
 
         if (dateToSpoof != null) {
             val jsFormattedAnchorDate =
@@ -57,22 +54,6 @@ class ZipAssetLoader(private val zipFile: ZipFile, private val loadedFileName: S
         }
 
         return "${loadedFileName}.androidplatform.net"
-    }
-
-    private fun checkShouldClearCache (manifest: JSONObject?): Boolean {
-        if (manifest == null || !manifest.has(KEY_WIPE_CACHE)) {
-            return false
-        }
-
-        return manifest.getBoolean(KEY_WIPE_CACHE)
-    }
-
-    private fun checkShouldClearCacheAndPreserveDisk (manifest: JSONObject?): Boolean {
-        if (manifest == null || !manifest.has(KEY_WIPE_CACHE_NO_DISK)) {
-            return false
-        }
-
-        return manifest.getBoolean(KEY_WIPE_CACHE_NO_DISK)
     }
 
     private fun manifestUseUnsafeURL (manifest: JSONObject?): String? {

--- a/app/src/main/java/foss/zip/offline/browser/offlinezipbrowser/ZipAssetLoader.kt
+++ b/app/src/main/java/foss/zip/offline/browser/offlinezipbrowser/ZipAssetLoader.kt
@@ -10,13 +10,8 @@ import androidx.webkit.WebViewClientCompat
 import org.json.JSONObject
 import java.io.ByteArrayInputStream
 import java.io.File
-import java.text.SimpleDateFormat
-import java.time.Duration
-import java.time.Instant
 import java.time.OffsetDateTime
-import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import java.util.Date
 import java.util.zip.ZipFile
 
 const val KEY_DATE_TO_SPOOF = "dateToSpoof"

--- a/app/src/main/java/foss/zip/offline/browser/offlinezipbrowser/ZipViewActivity.kt
+++ b/app/src/main/java/foss/zip/offline/browser/offlinezipbrowser/ZipViewActivity.kt
@@ -22,7 +22,7 @@ class ZipViewActivity : WebActivity() {
         val downloadHelperScript = assets.open("downloadNameHelper.js").bufferedReader(Charsets.UTF_8).readText()
         val dateOverrideScript = assets.open("dateReplacer.js").bufferedReader(Charsets.UTF_8).readText()
 
-        var zipAssetLoader = ZipAssetLoader(zip, name, dateOverrideScript, dateOverrideScript)
+        var zipAssetLoader = ZipAssetLoader(zip, name, downloadHelperScript, dateOverrideScript)
         webView.webViewClient = zipAssetLoader
         webviewSetup(webView)
 

--- a/app/src/main/java/foss/zip/offline/browser/offlinezipbrowser/ZipViewActivity.kt
+++ b/app/src/main/java/foss/zip/offline/browser/offlinezipbrowser/ZipViewActivity.kt
@@ -16,16 +16,17 @@ class ZipViewActivity : WebActivity() {
         setContentView(R.layout.activity_view)
         val webView = findViewById<WebView>(R.id.webview)
         val file = File(intent.getStringExtra(ZipConstants.FILE_NAME) ?: return)
-        val name = file.toUri().lastPathSegment
+        val name = file.toUri().lastPathSegment ?: "no-name"
         title = name
         val zip = ZipFile(file)
-        webView.webViewClient = ZipAssetLoader(zip, assets.open("downloadNameHelper.js").bufferedReader(Charsets.UTF_8).readText())
+        val downloadHelperScript = assets.open("downloadNameHelper.js").bufferedReader(Charsets.UTF_8).readText()
+        val dateOverrideScript = assets.open("dateReplacer.js").bufferedReader(Charsets.UTF_8).readText()
+
+        var zipAssetLoader = ZipAssetLoader(zip, name, dateOverrideScript, dateOverrideScript)
+        webView.webViewClient = zipAssetLoader
         webviewSetup(webView)
-        if (name?.contains(".unsafe_use_raw_domain") == true){
-            webView.loadUrl("https://${name.split(".unsafe_use_raw_domain").first()}/index.html")
-        } else {
-            webView.loadUrl("https://${name}.androidplatform.net/index.html")
-        }
+
+        webView.loadUrl("https://${zipAssetLoader.baseURL}/index.html")
     }
 
     companion object {


### PR DESCRIPTION
# Main Changes

## `dateToSpoof`

Offset based timestamp, loaded with OffsetDateTime.parse.
Values like "2025-01-30T19:00:00-05:00" will work.

## `useUnsafeURL`

Set the base url of the app to a "real" url. The app will still try to prevent access to the wider web.
